### PR TITLE
Adds namespace isolation functionality 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,12 @@ deploy:
       docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS";
       docker push nfvpe/net-attach-def-admission-controller:snapshot; 
       echo foo'
+  - provider: script
+    on:
+      branch: develop
+    script: >
+      bash -c '
+      docker tag nfvpe/net-attach-def-admission-controller nfvpe/net-attach-def-admission-controller:snapshot;
+      docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS";
+      docker push nfvpe/net-attach-def-admission-controller:snapshot; 
+      echo foo'

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -38,6 +38,7 @@ func main() {
 
 	/* register handlers */
 	http.HandleFunc("/validate", webhook.ValidateHandler)
+	http.HandleFunc("/isolate", webhook.IsolateHandler)
 
 	/* start serving */
 	err := http.ListenAndServeTLS(fmt.Sprintf("%s:%d", *address, *port), *cert, *key, nil)


### PR DESCRIPTION
Works in a rather basic fashion, essentially admits based on the presence of the NPWG-style annotation and then disallows any of those which container a reference a non-local namespace, that is -- by the presence of a `/` in the value of the annotation.

Needs: testing.

Has had some manual testing. However, this watches only pods -- Unsure what happens when say, you have the annotation elsewhere, like, what if you have the pod created by a deployment? That part I don't know.