### PR TITLE
Add default metrics value

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -88,6 +88,8 @@ func StartWatching() {
 	if err != nil {
 		glog.Fatalf("There was error accessing client set for net attach def %v", err)
 	}
+	//Initialize default metrics
+	localmetrics.InitMetrics()
 
 	informer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -19,7 +19,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("netdefattachment")
+var log = logf.Log.WithName("network-attachment-definition")
 var (
 	netDefInstanceEnabledCount      = 0.0
 	netDefInstanceSriovEnabledCount = 0.0
@@ -65,4 +65,10 @@ func UpdateNetDefAttachInstanceMetrics(tp string, val float64) {
 func SetNetDefAttachEnabledInstanceUp(tp string, val float64) {
 	NetDefAttachEnabledInstanceUp.With(prometheus.Labels{
 		"networks": tp}).Set(val)
+}
+
+//Initialize ... empty metrics
+func InitMetrics() {
+	UpdateNetDefAttachInstanceMetrics("any", 0.0)
+	UpdateNetDefAttachInstanceMetrics("sriov", 0.0)
 }


### PR DESCRIPTION
Default value for two metrics, so that telemetry can pick up default metrics.