### PR TITLE
Bug #2505: Fixed bug that was causing multus admission controller pods to not die when kill 1 is ran

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -112,8 +112,7 @@ func StartWatching() {
 	go c.Run(stopCh)
 
 	sigterm := make(chan os.Signal, 1)
-	signal.Notify(sigterm, syscall.SIGTERM)
-	signal.Notify(sigterm, syscall.SIGINT)
+	signal.Notify(sigterm, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
 	<-sigterm
 }
 


### PR DESCRIPTION
Fixed bug that was causing multus admission controller pods to not die when kill 1 is ran. The signal was not being notified when syscall.SIGKILL occurred, causing the bug. Thank you @aneeshkp for spotting this error.

I messed up the title, so here's the bug link: https://issues.redhat.com/browse/SDN-2505