### PR TITLE
webhook: add bond CNI validation to NAD admission controller

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -53,30 +53,55 @@ var (
 	clientset kubernetes.Interface
 )
 
-// validateCNIConfig verifies following fields
-// conf: 'type'
-// conflist: 'plugins' and 'type'
+
+// validateBondCNIConfig rejects bond CNI configs where linksInContainer is not
+// explicitly true. Set BOND_CNI_LINKS_IN_CONTAINER_FALSE_ALLOWED to permit
+// bond NADs where linksInContainer is false or absent.
+//
+// This is intended to become the default enforced behavior: in production
+// Kubernetes, bond CNI is expected to run as a chained plugin on top of
+// SR-IOV or host-device, where member interfaces are already present in the
+// pod network namespace before bond CNI executes.
+func validateBondCNIConfig(config map[string]any) error {
+	if v, ok := config["linksInContainer"].(bool); ok && v {
+		return nil
+	}
+	if os.Getenv("BOND_CNI_LINKS_IN_CONTAINER_FALSE_ALLOWED") != "" {
+		return nil
+	}
+	return fmt.Errorf("bond CNI plugin requires linksInContainer: true; set BOND_CNI_LINKS_IN_CONTAINER_FALSE_ALLOWED to permit linksInContainer: false")
+}
+
+// validateCNIConfig verifies following fields:
+// - single config: 'type' must be present; bond is not permitted as standalone config
+// - conflist: each entry in 'plugins' must have 'type'; bond plugins must have
+//   linksInContainer: true unless BOND_CNI_LINKS_IN_CONTAINER_FALSE_ALLOWED is set
 func validateCNIConfig(config []byte) error {
 	var c map[string]interface{}
 	if err := json.Unmarshal(config, &c); err != nil {
 		return err
 	}
 
-	// Identify target is single CNI config or plugins
-	if p, ok := c["plugins"]; ok {
-		// CNI conflist
-		// check 'type' field for each plugin in 'plugins'
-		plugins := p.([]interface{})
-		for _, v := range plugins {
-			plugin := v.(map[string]interface{})
-			if _, ok := plugin["type"]; !ok {
-				return fmt.Errorf("missing 'type' in plugins")
-			}
-		}
-	} else {
-		// single CNI config
+	p, ok := c["plugins"]
+	if !ok {
 		if _, ok := c["type"]; !ok {
 			return fmt.Errorf("missing 'type' in cni config")
+		}
+		if c["type"] == "bond" {
+			return fmt.Errorf("bond CNI must be used as a chained plugin in a conflist, not as a standalone config")
+		}
+		return nil
+	}
+
+	for _, v := range p.([]any) {
+		cniPlugin := v.(map[string]any)
+		if _, ok := cniPlugin["type"]; !ok {
+			return fmt.Errorf("missing 'type' in plugins")
+		}
+		if cniPlugin["type"] == "bond" {
+			if err := validateBondCNIConfig(cniPlugin); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -134,7 +159,6 @@ func validateNetworkAttachmentDefinition(netAttachDef netv1.NetworkAttachmentDef
 			return false, err
 		}
 		if err := validateCNIConfig(confBytes); err != nil {
-			err := errors.New("invalid config")
 			return false, err
 		}
 		_, err = libcni.ConfListFromBytes(confBytes)

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -174,6 +175,22 @@ var _ = Describe("Webhook", func() {
 			true, false,
 		),
 		Entry(
+			"bond as standalone config - always rejected",
+			netv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-valid-name"},
+				Spec:       netv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion": "0.3.0", "type": "bond", "name": "bond0", "linksInContainer": true}`},
+			},
+			false, true,
+		),
+		Entry(
+			"bond as standalone config linksInContainer false - always rejected",
+			netv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-valid-name"},
+				Spec:       netv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion": "0.3.0", "type": "bond", "name": "bond0", "linksInContainer": false}`},
+			},
+			false, true,
+		),
+		Entry(
 			"valid network config list",
 			netv1.NetworkAttachmentDefinition{
 				ObjectMeta: metav1.ObjectMeta{
@@ -205,5 +222,82 @@ var _ = Describe("Webhook", func() {
 			},
 			true, false,
 		),
+		Entry(
+			"conflist: bond with linksInContainer true - allowed",
+			netv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-valid-name"},
+				Spec: netv1.NetworkAttachmentDefinitionSpec{Config: `{
+					"cniVersion": "0.3.0",
+					"name": "bond-network",
+					"plugins": [{"type": "bond", "linksInContainer": true}, {"type": "tuning"}]
+				}`},
+			},
+			true, false,
+		),
+		Entry(
+			"conflist: bond with linksInContainer false - rejected by default",
+			netv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-valid-name"},
+				Spec: netv1.NetworkAttachmentDefinitionSpec{Config: `{
+					"cniVersion": "0.3.0",
+					"name": "bond-network",
+					"plugins": [{"type": "bond", "linksInContainer": false}, {"type": "tuning"}]
+				}`},
+			},
+			false, true,
+		),
 	)
+
+	Describe("Bond CNI validation with BOND_CNI_LINKS_IN_CONTAINER_FALSE_ALLOWED set", func() {
+		BeforeEach(func() {
+			os.Setenv("BOND_CNI_LINKS_IN_CONTAINER_FALSE_ALLOWED", "true")
+		})
+		AfterEach(func() {
+			os.Unsetenv("BOND_CNI_LINKS_IN_CONTAINER_FALSE_ALLOWED")
+		})
+
+		DescribeTable("validateNetworkAttachmentDefinition",
+			func(in netv1.NetworkAttachmentDefinition, out bool, shouldFail bool) {
+				actualOut, err := validateNetworkAttachmentDefinition(in)
+				Expect(actualOut).To(Equal(out))
+				if shouldFail {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			},
+			Entry(
+				"bond as standalone config - rejected even with env set",
+				netv1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-valid-name"},
+					Spec:       netv1.NetworkAttachmentDefinitionSpec{Config: `{"cniVersion": "0.3.0", "type": "bond", "name": "bond0", "linksInContainer": false}`},
+				},
+				false, true,
+			),
+			Entry(
+				"conflist: bond with linksInContainer false - allowed",
+				netv1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-valid-name"},
+					Spec: netv1.NetworkAttachmentDefinitionSpec{Config: `{
+						"cniVersion": "0.3.0",
+						"name": "bond-network",
+						"plugins": [{"type": "bond", "linksInContainer": false}, {"type": "tuning"}]
+					}`},
+				},
+				true, false,
+			),
+			Entry(
+				"conflist: bond without linksInContainer - allowed",
+				netv1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-valid-name"},
+					Spec: netv1.NetworkAttachmentDefinitionSpec{Config: `{
+						"cniVersion": "0.3.0",
+						"name": "bond-network",
+						"plugins": [{"type": "bond"}, {"type": "tuning"}]
+					}`},
+				},
+				true, false,
+			),
+		)
+	})
 })


### PR DESCRIPTION
## Summary

In k8s production environment we suggest admins to use linksInContainer,
which means bond CNI operates on interfaces already present in the pod
network namespace, as expected when chained after SR-IOV or host-device plugins.

- Single-config bond: always rejected; bond must be used as a chained plugin in a conflist, not as a standalone config
- Conflist bond + `linksInContainer:true`: allowed
- Conflist bond + `linksInContainer:false/missing`: rejected unless `BOND_CNI_LINKS_IN_CONTAINER_FALSE_ALLOWED` env var is set
- Any non-bond plugin: unaffected



🤖 Generated with [Claude Code](https://claude.com/claude-code)